### PR TITLE
Update file.py's initial_diff() to list contents

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -358,7 +358,22 @@ def initial_diff(path, state, prev_state):
     if prev_state != state:
         diff['before']['state'] = prev_state
         diff['after']['state'] = state
+        if state == 'absent':
+            walklist = {
+                'directories': [],
+                'files': [],
+            }
+            for base_path, sub_folders, files in os.walk(path):
+                for folder in sub_folders:
+                    folderpath = os.path.join(base_path, folder)
+                    walklist['directories'].append(folderpath)
 
+                for filename in files:
+                    filepath = os.path.join(base_path, filename)
+                    walklist['files'].append(filepath)
+
+            diff['before']['path_content'] = walklist
+            
     return diff
 
 #
@@ -472,6 +487,8 @@ def ensure_absent(path):
     result = {}
 
     if prev_state != 'absent':
+        diff = initial_diff(path, 'absent', prev_state)
+
         if not module.check_mode:
             if prev_state == 'directory':
                 try:
@@ -486,7 +503,6 @@ def ensure_absent(path):
                         raise AnsibleModuleError(results={'msg': "unlinking failed: %s " % to_native(e),
                                                           'path': path})
 
-        diff = initial_diff(path, 'absent', prev_state)
         result.update({'path': path, 'changed': True, 'diff': diff, 'state': 'absent'})
     else:
         result.update({'path': path, 'changed': False, 'state': 'absent'})


### PR DESCRIPTION
##### SUMMARY
Currently when using `file: "path=someFolderPath state=absent"`, if a folder is defined for removing, the diff result only shows the state change, not the files removed. I believe a small tweak to `initial_diff` would make sense in the case of using `state=absent` to make it more clear what's to be removed

Fixes #55882

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
[Modules/Files/File.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/files/file.py)

##### ADDITIONAL INFORMATION
When logging ansible output, either to a file, ARA, or else where, having a detailed record of what was changed is useful for in case anything was later found to be incorrectly updated. This is especially useful when bringing non-ansible managed servers into an ansible stack, as they're likely to be _snowflakes_, with configuration that could break if applying existing roles to it where you would think they overlap.  
  
In my case this issue happened where a default folder that wasn't used any other server got removed from the 1 server it was used on, and lacking a log of what was removed made the recovery process all the more blind.  
As I believe it's generally good practice to run a **--check** run first, adding in a diff of what would be deleted in the situation of the absent statement should protect others from inadvertently removing important files they weren't aware of.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

###### Example playbook tested with stable 2.7 branch
```yaml
- name: Create example folders
  file:
    path: "{{ item }}"
    state: directory
  with_items:
    - /tmp/example_folder
    - /tmp/example_folder/sub_folder

- name: Create example files
  file:
    path: "{{ item }}"
    state: touch
  with_items:
    - /tmp/example_folder/example_file.tmp
    - /tmp/example_folder/sub_folder/sub_file.tmp

- name: remove example folders and files
  file:
    path: /tmp/example_folder
    state: absent
```

###### Before
```log
TASK [remove example folders and files] ********************************************************************************
--- Output before change
+++ after
@@ -1,13 +1,4 @@
 {
     "path": "/tmp/example_folder",
-    "state": "directory"
+    "state": "absent"
 }
```
###### Output after change
```log
TASK [remove example folders and files] ********************************************************************************
--- before
+++ after
@@ -1,13 +1,4 @@
 {
     "path": "/tmp/example_folder",
-    "path_content": {
-        "directories": [
-            "/tmp/example_folder/sub_folder"
-        ],
-        "files": [
-            "/tmp/example_folder/example_file.tmp",
-            "/tmp/example_folder/sub_folder/sub_file.tmp"
-        ]
-    },
-    "state": "directory"
+    "state": "absent"
 }
```